### PR TITLE
Remove deprecation warning during migrate about timestamps

### DIFF
--- a/lib/generators/public_activity/migration/templates/migration.rb
+++ b/lib/generators/public_activity/migration/templates/migration.rb
@@ -9,7 +9,7 @@ class CreateActivities < ActiveRecord::Migration
       t.text    :parameters
       t.belongs_to :recipient, :polymorphic => true
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :activities, [:trackable_id, :trackable_type]


### PR DESCRIPTION
This warning occurs when you tried to rake:db migrate in a rails 4.2
application. It's a deprecation warning for upcoming rails 5, a null
option need to be given :

DEPRECATION WARNING: `#timestamp` was called without specifying an
option for `null`. In Rails 5, this behavior will change to `null:
false`. You should manually specify `null: true` to prevent the behavior
of your existing migrations from changing. (called from block in up at
db/migrate/20151104181305_create_activities.rb:12)