### PR TITLE
rescue from Cell::TemplateMissingError

### DIFF
--- a/lib/public_activity/renderable.rb
+++ b/lib/public_activity/renderable.rb
@@ -130,7 +130,7 @@ module PublicActivity
 
       begin 
         context.render params.merge(partial: partial, layout: layout, locals: locals)
-      rescue ActionView::MissingTemplate => e
+      rescue ActionView::MissingTemplate, Cell::TemplateMissingError => e
         if params[:fallback] == :text
           context.render :text => self.text(params)
         elsif params[:fallback].present?


### PR DESCRIPTION
Cells throws Cell::TemplateMissingError instead of ActionView::MissingTemplate so it is impossible to use fallback in render_activity within cells.
