### PR TITLE
fix rails 5 deprecation warnings

### DIFF
--- a/lib/public_activity/orm/active_record/activity.rb
+++ b/lib/public_activity/orm/active_record/activity.rb
@@ -9,10 +9,12 @@ module PublicActivity
 
         # Define polymorphic association to the parent
         belongs_to :trackable, :polymorphic => true
-        # Define ownership to a resource responsible for this activity
-        belongs_to :owner, :polymorphic => true
-        # Define ownership to a resource targeted by this activity
-        belongs_to :recipient, :polymorphic => true
+        with_options(::ActiveRecord::VERSION::MAJOR >= 5 ? { :required => false } : { }) do
+          # Define ownership to a resource responsible for this activity
+          belongs_to :owner, :polymorphic => true
+          # Define ownership to a resource targeted by this activity
+          belongs_to :recipient, :polymorphic => true
+        end
         # Serialize parameters Hash
         serialize :parameters, Hash
 

--- a/lib/public_activity/utility/store_controller.rb
+++ b/lib/public_activity/utility/store_controller.rb
@@ -26,7 +26,12 @@ module PublicActivity
     extend ActiveSupport::Concern
 
     included do
-      before_filter :store_controller_for_public_activity
+      # use :before_action instead of deprecated before_filter
+      if respond_to? :before_action
+        before_action :store_controller_for_public_activity
+      else
+        before_filter :store_controller_for_public_activity
+      end
     end
 
     # Before filter executed to remember current controller


### PR DESCRIPTION
- use :before_action instead of :before_filter
- add "require: false" option to belongs_to associations