### PR TITLE
Include ViewHelpers through ActiveSupport

### DIFF
--- a/lib/public_activity/utility/view_helpers.rb
+++ b/lib/public_activity/utility/view_helpers.rb
@@ -23,5 +23,8 @@ module PublicActivity
     end
   end
 
-  ActionView::Base.class_eval { include ViewHelpers }
+end
+
+ActiveSupport.on_load(:action_view) do
+  include PublicActivity::ViewHelpers
 end


### PR DESCRIPTION
Resolves  https://github.com/chaps-io/public_activity/issues/271

with:

```
ActiveSupport.on_load(:action_view) do
  include PublicActivity::ViewHelpers
end
```
