### PR TITLE
Rails 5.1 compatibility for update action (for PR #290)

### DIFF
--- a/lib/public_activity/actions/update.rb
+++ b/lib/public_activity/actions/update.rb
@@ -11,7 +11,8 @@ module PublicActivity
 
     # Creates activity upon modification of the tracked model
     def activity_on_update
-      create_activity(:update) if changed?
+      # Either use #changed? method for Rails < 5.1 or #saved_changes? for recent versions
+      create_activity(:update) if respond_to?(:saved_changes?) ? saved_changes? : changed?
     end
   end
 end


### PR DESCRIPTION
PR #290 uses deprecated method `changed?` in Rails >= 5.1
This fixes the issue