### PR TITLE
Adding license info to the Gemspec.

### DIFF
--- a/public_activity.gemspec
+++ b/public_activity.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/pokonski/public_activity'
   s.summary = "Easy activity tracking for ActiveRecord models"
   s.description = "Easy activity tracking for your ActiveRecord models. Provides Activity model with details about actions performed by your users, like adding comments, responding etc."
+  s.license = "MIT"
 
   s.files = `git ls-files lib`.split("\n") + ['Gemfile','Rakefile','README.md', 'MIT-LICENSE']
   s.test_files = `git ls-files test`.split("\n")


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). If the license info is in the gemspec it will be published via the RubyGems API and that makes it easier for VersionEye and other OS vendors to fetch the actual license of the project. 