### PR TITLE
Set self.abstract_class = true

### DIFF
--- a/lib/public_activity/orm/active_record/activity.rb
+++ b/lib/public_activity/orm/active_record/activity.rb
@@ -6,6 +6,7 @@ module PublicActivity
       class Activity < ::ActiveRecord::Base
         include Renderable
         self.table_name = PublicActivity.config.table_name
+        self.abstract_class = true
 
         # Define polymorphic association to the parent
         belongs_to :trackable, :polymorphic => true

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -104,6 +104,11 @@ describe PublicActivity::Common do
     activity.owner.must_equal @owner
   end
 
+  it 'reports PublicActivity::Activity as the base class' do
+    subject.save
+    subject.activities.last.class.base_class.must_equal PublicActivity::Activity
+  end
+
   describe '#prepare_key' do
     describe 'for class#activity_key method' do
       before do

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -105,8 +105,10 @@ describe PublicActivity::Common do
   end
 
   it 'reports PublicActivity::Activity as the base class' do
-    subject.save
-    subject.activities.last.class.base_class.must_equal PublicActivity::Activity
+    if ENV["PA_ORM"] == "active_record" # Only relevant for ActiveRecord
+      subject.save
+      subject.activities.last.class.base_class.must_equal PublicActivity::Activity
+    end
   end
 
   describe '#prepare_key' do


### PR DESCRIPTION
`base_class` in ActiveRecord returns
`PublicActivity::ORM::ActiveRecord::Activity` incorrectly. Since
`PublicActivity::ORM::ActiveRecord::Activity` is really an abstract
class for all intents and purposes, it should be declared so that
`base_class` returns `PublicActivity::Activity` instead.

My use case was using the `unread` gem to track who had read an
activity. It uses `base_class` to record the polymorphic type of the
`readable` which is the Activity in this case.

All the tests passed with this addition but I’ve added another to
ensure that `base_class` returns the correct value.