### PR TITLE
Fix issue that prevents rake db:schema:load from working

### DIFF
--- a/lib/public_activity/orm/active_record/activity.rb
+++ b/lib/public_activity/orm/active_record/activity.rb
@@ -26,7 +26,9 @@ module PublicActivity
         end
 
         # Serialize parameters Hash
-        serialize :parameters, Hash unless [:json, :jsonb, :hstore].include?(columns_hash['parameters'].type)
+        if table_exists? && !columns_hash['parameters'].type.in?([:json, :jsonb, :hstore])
+          serialize :parameters, Hash
+        end
 
         if ::ActiveRecord::VERSION::MAJOR < 4 || defined?(ProtectedAttributes)
           attr_accessible :key, :owner, :parameters, :recipient, :trackable


### PR DESCRIPTION
A check was added in ec2cbdb to only serialize `Activity#parameters` as `Hash` if this column is not `json`, `jsonb` or `hstore`.

Since this is executed on the class level, it provokes an error on environment load if for some reason the database or the table isn't created (e.g. when running any rake task that loads the environment, like `rake db:schema:load`). I added a check for `table_exists?`, which prevents the error in those scenarios.

