### PR TITLE
active_record: Catch PG::ConnectionBad

### DIFF
--- a/lib/public_activity/orm/active_record/activity.rb
+++ b/lib/public_activity/orm/active_record/activity.rb
@@ -35,6 +35,8 @@ module PublicActivity
           end
         rescue ::ActiveRecord::NoDatabaseError => e
           warn("[WARN] database doesn't exist. Skipping PublicActivity::Activity#parameters's serialization")
+        rescue ::PG::ConnectionBad => e
+          warn("[WARN] couldn't connect to database. Skipping PublicActivity::Activity#parameters's serialization")
         end
 
         if ::ActiveRecord::VERSION::MAJOR < 4 || defined?(ProtectedAttributes)


### PR DESCRIPTION
Similar to #327 but for Postgres.

We are getting the following when running `RAILS_ENV=production bundle exec rake assets:clean` in our tests:

```
rake aborted!
PG::ConnectionBad: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
```

This is because the test servers are trying to use the production env vars to access the database but these are not set in our test environment (for obvious reasons).

I'm not sure if having a rescue for each error is the best solution but may prevent catching unrelated errors.