### PR TITLE
Add create_activity! method.

### DIFF
--- a/lib/public_activity/common.rb
+++ b/lib/public_activity/common.rb
@@ -259,6 +259,20 @@ module PublicActivity
       nil
     end
 
+    # Directly saves activity to database. Works the same as create_activity
+    # but throws validation error for each supported ORM.
+    #
+    # @see #create_activity
+    def create_activity!(*args)
+      return unless self.public_activity_enabled?
+      options = prepare_settings(*args)
+
+      if call_hook_safe(options[:key].split('.').last)
+        reset_activity_instance_options
+        return PublicActivity::Adapter.create_activity!(self, options)
+      end
+    end
+
     # Prepares settings used during creation of Activity record.
     # params passed directly to tracked model have priority over
     # settings specified in tracked() method

--- a/lib/public_activity/orm/active_record/adapter.rb
+++ b/lib/public_activity/orm/active_record/adapter.rb
@@ -12,6 +12,11 @@ module PublicActivity
         def self.create_activity(trackable, options)
           trackable.activities.create options
         end
+
+        # Creates activity on `trackable` with `options`; throws error on validation failure
+        def self.create_activity!(trackable, options)
+          trackable.activities.create! options
+        end
       end
     end
   end

--- a/lib/public_activity/orm/mongo_mapper/adapter.rb
+++ b/lib/public_activity/orm/mongo_mapper/adapter.rb
@@ -8,6 +8,11 @@ module PublicActivity
         def self.create_activity(trackable, options)
           trackable.activities.create options
         end
+
+        # Creates activity on `trackable` with `options`; throws error on validation failure
+        def self.create_activity!(trackable, options)
+          trackable.activities.create! options
+        end
       end
     end
   end

--- a/lib/public_activity/orm/mongoid/adapter.rb
+++ b/lib/public_activity/orm/mongoid/adapter.rb
@@ -8,6 +8,11 @@ module PublicActivity
         def self.create_activity(trackable, options)
           trackable.activities.create options
         end
+
+        # Creates activity on `trackable` with `options`; throws error on validation failure
+        def self.create_activity!(trackable, options)
+          trackable.activities.create! options
+        end
       end
     end
   end

--- a/test/test_common.rb
+++ b/test/test_common.rb
@@ -50,6 +50,13 @@ describe PublicActivity::Common do
     subject.create_activity("some.key").wont_be_nil
   end
 
+  it '#create_activity! returns a new activity object' do
+    subject.save
+    activity = subject.create_activity!("some.key")
+    assert activity.persisted?
+    assert_equal 'article.some.key', activity.key
+  end
+
   it 'update action should not create activity on save unless model changed' do
     subject.save
     before_count = subject.activities.count


### PR DESCRIPTION
Overall pretty simple PR: uses the create! method to add create_activity! which will throw an error on validation failure for each of the three supported ORMs from issue #333 

Added a single test similar to one of the create_activity tests, didn't think it was a good idea to add a validation using class_eval in the tests, open to ideas in regards to testing more etc. 